### PR TITLE
Fixed typographical error, changed aplication to application in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ By default, You can [find these settings](https://github.com/Harazaki/PHP-BOOTST
 What will be set ?
 - A Cool Name For Your Application
 - Directory / Patch setting's
-- Your APLICATION URL
+- Your APPLICATION URL
 - Current THEME's And Controller Setting's
 - Languange & Device Setting's
 


### PR DESCRIPTION
@Harazaki, I've corrected a typographical error in the documentation of the [PHP-BOOTSTRAP](https://github.com/Harazaki/PHP-BOOTSTRAP) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.